### PR TITLE
feat: add metrics_definitions.json

### DIFF
--- a/data/metrics_definitions.json
+++ b/data/metrics_definitions.json
@@ -1,42 +1,32 @@
-[
-    {
-        "cer":
+{
+    "cer":
         {
             "label": "CER",
             "short_descr": "CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
             "url": "https://kba.github.io/en/spec/ocrd_eval#character-error-rate-cer"
-        }
-    },
-    {
-        "cer_range":
+        },
+    "cer_range":
         {
             "label": "CER (Range)",
             "short_descr": "Minimum and maximum of CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
             "url": ""
-        }
-    },
-    {
-        "wer":
+        },
+    "wer":
         {
             "label": "WER",
             "short_descr": "CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
             "url": "https://kba.github.io/en/spec/ocrd_eval#wer-granularity"
-        }
-    },
-    {
-        "wall_time":
+        },
+    "wall_time":
         {
             "label": "Wall Time",
             "short_descr": "Actual time needed for processing workflow",
             "url": "https://kba.github.io/en/spec/ocrd_eval#wall-time"
-        }
-    },
-    {
-        "cpu_time":
+        },
+    "cpu_time":
         {
             "label": "CPU Time",
             "short_descr": "Cumulative CPU time used for processing workflow",
             "url": "https://kba.github.io/en/spec/ocrd_eval#cpu-time"
         }
-    }
-]
+}

--- a/data/metrics_definitions.json
+++ b/data/metrics_definitions.json
@@ -1,0 +1,37 @@
+[
+    {
+        "cer":
+        {
+            "short_descr": "CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
+            "url": "https://kba.github.io/en/spec/ocrd_eval#character-error-rate-cer"
+        }
+    },
+    {
+        "cer_range":
+        {
+            "short_descr": "Minimum and maximum of CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
+            "url": ""
+        }
+    },
+    {
+        "wer":
+        {
+            "short_descr": "CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
+            "url": "https://kba.github.io/en/spec/ocrd_eval#wer-granularity"
+        }
+    },
+    {
+        "wall_time":
+        {
+            "short_descr": "Actual time needed for processing workflow",
+            "url": "https://kba.github.io/en/spec/ocrd_eval#wall-time"
+        }
+    },
+    {
+        "cpu_time":
+        {
+            "short_descr": "Cumulative CPU time used for processing workflow",
+            "url": "https://kba.github.io/en/spec/ocrd_eval#cpu-time"
+        }
+    }
+]

--- a/data/metrics_definitions.json
+++ b/data/metrics_definitions.json
@@ -2,6 +2,7 @@
     {
         "cer":
         {
+            "label": "CER",
             "short_descr": "CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
             "url": "https://kba.github.io/en/spec/ocrd_eval#character-error-rate-cer"
         }
@@ -9,6 +10,7 @@
     {
         "cer_range":
         {
+            "label": "CER (Range)",
             "short_descr": "Minimum and maximum of CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
             "url": ""
         }
@@ -16,6 +18,7 @@
     {
         "wer":
         {
+            "label": "WER",
             "short_descr": "CER calculated over the text of a whole page (in by_page) or combined text of all pages (in document_wide)",
             "url": "https://kba.github.io/en/spec/ocrd_eval#wer-granularity"
         }
@@ -23,6 +26,7 @@
     {
         "wall_time":
         {
+            "label": "Wall Time",
             "short_descr": "Actual time needed for processing workflow",
             "url": "https://kba.github.io/en/spec/ocrd_eval#wall-time"
         }
@@ -30,6 +34,7 @@
     {
         "cpu_time":
         {
+            "label": "CPU Time",
             "short_descr": "Cumulative CPU time used for processing workflow",
             "url": "https://kba.github.io/en/spec/ocrd_eval#cpu-time"
         }


### PR DESCRIPTION
This PR adds a `metrics_definitions.json` that holds a short description (taken from the [ocrd_eval.schema.json](https://github.com/OCR-D/spec/blob/fe9d6ffd2c6d4e6048a718027733007f3433add5/ocrd_eval.schema.json)) as well as a link to the more elaborate definitions (currently pointing to a test instance) to the repository.

Closes OCR-D/zenhub#132