### PR TITLE
Fix json ld

### DIFF
--- a/data/workflows.json
+++ b/data/workflows.json
@@ -3,7 +3,18 @@
         "eval_workflow_id": "wf-data16_ant_simple-eval",
         "label": "Workflow on data 16_ant_simple",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/16_ant_simple.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/16_ant_simple.zip",
+                "label": "Evaluation workspace for 16_ant_simple"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -11,15 +22,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/16_ant_simple.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 17604,
+                "wall_time": 18567,
                 "cer": 0.07452119312897007,
                 "cer_min_max": [
                     0.037037037037037035,
@@ -70,7 +77,18 @@
         "eval_workflow_id": "wf-data18_frak_simple-eval",
         "label": "Workflow on data 18_frak_simple",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/18_frak_simple.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/18_frak_simple.zip",
+                "label": "Evaluation workspace for 18_frak_simple"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -78,15 +96,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/18_frak_simple.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 10097,
+                "wall_time": 11912,
                 "cer": 0.02493765586034913,
                 "cer_min_max": [
                     0.02493765586034913,
@@ -113,7 +127,18 @@
         "eval_workflow_id": "wf-data18_fontmix_complex-eval",
         "label": "Workflow on data 18_fontmix_complex",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/18_fontmix_complex.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/18_fontmix_complex.zip",
+                "label": "Evaluation workspace for 18_fontmix_complex"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -121,15 +146,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/18_fontmix_complex.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 29354,
+                "wall_time": 34542,
                 "cer": 0.2043347058754337,
                 "cer_min_max": [
                     0.04063745019920319,
@@ -192,7 +213,18 @@
         "eval_workflow_id": "wf-data17_frak_simple-eval",
         "label": "Workflow on data 17_frak_simple",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/17_frak_simple.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/17_frak_simple.zip",
+                "label": "Evaluation workspace for 17_frak_simple"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -200,15 +232,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/17_frak_simple.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 17522,
+                "wall_time": 21458,
                 "cer": 0.08427970798416445,
                 "cer_min_max": [
                     0.05025996533795494,
@@ -259,7 +287,18 @@
         "eval_workflow_id": "wf-data16_ant_complex-eval",
         "label": "Workflow on data 16_ant_complex",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/16_ant_complex.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/16_ant_complex.zip",
+                "label": "Evaluation workspace for 16_ant_complex"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -267,15 +306,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/16_ant_complex.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 18229,
+                "wall_time": 18603,
                 "cer": 0.10240852523716282,
                 "cer_min_max": [
                     0.07124352331606218,
@@ -326,7 +361,18 @@
         "eval_workflow_id": "wf-data16_frak_simple-eval",
         "label": "Workflow on data 16_frak_simple",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/16_frak_simple.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/16_frak_simple.zip",
+                "label": "Evaluation workspace for 16_frak_simple"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -334,15 +380,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/16_frak_simple.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 34116,
+                "wall_time": 37695,
                 "cer": 0.13618698942582164,
                 "cer_min_max": [
                     0.014285714285714285,
@@ -429,7 +471,18 @@
         "eval_workflow_id": "wf-data19_ant_simple-eval",
         "label": "Workflow on data 19_ant_simple",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/19_ant_simple.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/19_ant_simple.zip",
+                "label": "Evaluation workspace for 19_ant_simple"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -437,15 +490,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/19_ant_simple.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 21394,
+                "wall_time": 25679,
                 "cer": 0.08406355853675973,
                 "cer_min_max": [
                     0.04055496264674493,
@@ -496,7 +545,18 @@
         "eval_workflow_id": "wf-data19_frak_simple-eval",
         "label": "Workflow on data 19_frak_simple",
         "metadata": {
-            "data_creation_workflow": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+            "ocr_workflow": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt",
+                "label": "OCR Workflow minimal"
+            },
+            "gt_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-data/blob/main/19_frak_simple.ocrd.zip",
+                "label": "TODO"
+            },
+            "eval_workspace": {
+                "@id": "https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/19_frak_simple.zip",
+                "label": "Evaluation workspace for 19_frak_simple"
+            },
             "workflow_steps": [
                 "ocrd-tesserocr-recognize",
                 "ocrd-dinglehopper",
@@ -504,15 +564,11 @@
                 "ocrd-dinglehopper"
             ],
             "workflow_model": "Fraktur_GT4HistOCR",
-            "eval_workflow_url": "",
-            "eval_data": "",
-            "eval_tool": "ocrd-dinglehopper vNone",
-            "gt_data": "https://github.com/OCR-D/quiver-data/blob/main/19_frak_simple.ocrd.zip",
-            "data_properties": ""
+            "document_metadata": ""
         },
         "evaluation_results": {
             "document_wide": {
-                "wall_time": 13009,
+                "wall_time": 14532,
                 "cer": 0.004721435316336166,
                 "cer_min_max": [
                     0.004721435316336166,

--- a/quiver/benchmark_extraction.py
+++ b/quiver/benchmark_extraction.py
@@ -3,9 +3,10 @@ benchmarking. It extracts the relevant information from the NextFlow processes. 
 
 import json
 import sys
-from os import scandir, listdir
-from re import search
 import xml.etree.ElementTree as ET
+from os import listdir, scandir
+from re import search
+from typing import Any, Dict, List, Union
 
 METS = '{http://www.loc.gov/METS/}'
 
@@ -22,14 +23,17 @@ METS = '{http://www.loc.gov/METS/}'
  #   }
  # }
 
-def make_result_json(workspace_path, mets_path):
-    data_name = workspace_path.split('/')[-2]
+def make_result_json(workspace_path: str, mets_path: str) -> Dict[str, Union[str, Dict]]:
+    data_name = get_workspace_name(workspace_path)
     return {
         'eval_workflow_id': 'wf-data'+ data_name + '-eval',
         'label': 'Workflow on data ' + data_name,
         'metadata': make_metadata(workspace_path, mets_path),
         'evaluation_results': extract_benchmarks(workspace_path, mets_path)
     }
+
+def get_workspace_name(workspace_path: str) -> str:
+    return workspace_path.split('/')[-2]
 
 #    "eval_workflow": {
 #        "@id": "https://github.com/OCR-D/quiver/tree/data/workflows/eval1.nf",
@@ -40,7 +44,7 @@ def make_result_json(workspace_path, mets_path):
 #        "label": "OCR result workspace 3000"
 #      }
 
-def make_metadata(workspace_path, mets_path):
+def make_metadata(workspace_path: str, mets_path: str) -> Dict[str, Union[str, Dict]]:
     return {
             'ocr_workflow': get_ocr_workflow(workspace_path),
             #'eval_workflow': get_eval_workflow(workspace_path),
@@ -52,7 +56,7 @@ def make_metadata(workspace_path, mets_path):
             'document_metadata': ''
         }
 
-def get_ocr_workflow(workspace_path):
+def get_ocr_workflow(workspace_path: str) -> Dict[str, str]:
     for file_name in listdir(workspace_path):
         if '.txt.nf' in file_name:
             workflow = file_name.split('.')[0]
@@ -62,8 +66,8 @@ def get_ocr_workflow(workspace_path):
         'label': label
     }
 
-def get_eval_workspace(workspace_path):
-    workspace = workspace_path.split('/')[-2]
+def get_eval_workspace(workspace_path: str) -> Dict[str, str]:
+    workspace = get_workspace_name(workspace_path)
     url = 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/' + workspace + '.zip'
     label = f'Evaluation workspace for {workspace}'
     return {
@@ -71,12 +75,12 @@ def get_eval_workspace(workspace_path):
         'label': label
     }
 
-def get_element_from_mets(mets_path, xpath):
+def get_element_from_mets(mets_path: str, xpath: str) -> List[str]:
     with open(mets_path, 'r', encoding='utf-8') as f:
         tree = ET.parse(f)
         return tree.findall(xpath)
 
-def get_workflow_steps(mets_path):
+def get_workflow_steps(mets_path: str) -> List[str]:
     xpath =f'.//{METS}agent[@ROLE="OTHER"]/{METS}name'
     name_elements = get_element_from_mets(mets_path, xpath)
     formatted_names = []
@@ -85,19 +89,19 @@ def get_workflow_steps(mets_path):
 
     return formatted_names
 
-def get_workflow_model(mets_path):
+def get_workflow_model(mets_path: str) -> str:
     OCRD = '{https://ocr-d.de}'
     xpath = f'.//{METS}agent[@OTHERROLE="layout/segmentation/region"]/{METS}note[@{OCRD}option="parameter"]'
     parameters = get_element_from_mets(mets_path, xpath)[0].text
     params_json = json.loads(parameters)
     return params_json['model']
 
-def get_eval_tool(mets_path):
+def get_eval_tool(mets_path: str) -> str:
     xpath = f'.//{METS}agent[@OTHERROLE="recognition/text-recognition"]/{METS}name'
     return get_element_from_mets(mets_path, xpath)[0].text
 
-def get_gt_workspace(workspace_path):
-    current_workspace = workspace_path.split('/')[-2]
+def get_gt_workspace(workspace_path: str) -> Dict[str, str]:
+    current_workspace = get_workspace_name(workspace_path)
     url = 'https://github.com/OCR-D/quiver-data/blob/main/' + current_workspace + '.ocrd.zip'
     label = 'TODO'
     return {
@@ -105,26 +109,22 @@ def get_gt_workspace(workspace_path):
         'label': label
     }
 
-def extract_benchmarks(workspace_path, mets_path):
+def extract_benchmarks(workspace_path: str, mets_path: str) -> Dict[str, Dict[str, Any]]:
     json_dirs = get_eval_jsons(workspace_path)
 
-    result = {
+    return {
         'document_wide': make_document_wide_eval_results(workspace_path),
         'by_page': make_eval_results_by_page(json_dirs, mets_path)
     }
-        
-        
 
-    return result
-
-def make_document_wide_eval_results(workspace_path):
+def make_document_wide_eval_results(workspace_path: str) -> Dict[str, Union[float, List[float]]]:
     return {
         'wall_time': get_nf_completed_stats(workspace_path),
         'cer': get_mean_cer(workspace_path, 'SEG-LINE'),
         'cer_min_max': get_cer_min_max(workspace_path, 'SEG-LINE')
     }
 
-def get_nf_completed_stats(workspace_path):
+def get_nf_completed_stats(workspace_path: str) -> float:
     result_path = workspace_path + '/../../nf-results/'
 
     for file_name in listdir(workspace_path + '/../../nf-results'):
@@ -137,11 +137,11 @@ def get_nf_completed_stats(workspace_path):
     return duration
 
 
-def get_mean_cer(workspace_path, gt_type):
+def get_mean_cer(workspace_path: str, gt_type: str) -> float:
     cers = get_cers_for_gt_type(workspace_path, gt_type)
     return sum(cers) / len(cers)
 
-def get_cers_for_gt_type(workspace_path, gt_type):
+def get_cers_for_gt_type(workspace_path: str, gt_type: str) -> List[float]:
     eval_jsons = []
     eval_dir_path = workspace_path + '/OCR-D-EVAL-' + gt_type + '/'
     for file_name in listdir(eval_dir_path):
@@ -154,11 +154,11 @@ def get_cers_for_gt_type(workspace_path, gt_type):
             cers.append(json_file['cer'])
     return cers
 
-def get_cer_min_max(workspace_path, gt_type):
+def get_cer_min_max(workspace_path: str, gt_type: str) -> List[float]:
     cers = get_cers_for_gt_type(workspace_path, gt_type)
     return [min(cers), max(cers)]
 
-def make_eval_results_by_page(json_dirs, mets_path):
+def make_eval_results_by_page(json_dirs: str, mets_path: str) -> List[object]:
     result = []
     for d in json_dirs:
         for file_path in json_dirs[d]:
@@ -166,13 +166,13 @@ def make_eval_results_by_page(json_dirs, mets_path):
 
     return result
 
-def get_eval_dirs(workspace_dir):
+def get_eval_dirs(workspace_dir: str) -> List[str]:
     list_subfolders_with_paths = [f.path for f in scandir(workspace_dir) if f.is_dir()]
     eval_dirs = [name for name in list_subfolders_with_paths if search('EVAL', name)]
     return eval_dirs
 
 
-def get_eval_jsons(workspace_dir):
+def get_eval_jsons(workspace_dir: str) -> Dict[str, List[str]]:
     eval_dirs = get_eval_dirs(workspace_dir)
     result = {}
     for eval_dir in eval_dirs:
@@ -182,20 +182,20 @@ def get_eval_jsons(workspace_dir):
     return result
 
 
-def get_page_id(json_file_path, mets_path):
+def get_page_id(json_file_path: str, mets_path: str) -> str:
     json_file_name = get_file_name_from_path(json_file_path)
     gt_file_name = json_file_name.replace('EVAL', 'GT')
     xpath = f'.//{METS}fptr[@FILEID="{gt_file_name}"]/..'
     return get_element_from_mets(mets_path, xpath)[0].attrib['ID']
 
 
-def get_file_name_from_path(json_file_path):
+def get_file_name_from_path(json_file_path: str) -> str:
     json_file_name = json_file_path.split('/')[-1]
     name_wo_ext = json_file_name.split('.')[0]
     return name_wo_ext
 
 
-def get_metrics_for_page(json_file_path, mets_path):
+def get_metrics_for_page(json_file_path: str, mets_path: str) -> Dict[str, Union[str, float]]:
     with open(json_file_path, 'r', encoding='utf-8') as file:
         eval_file = json.load(file)
 

--- a/quiver/benchmark_extraction.py
+++ b/quiver/benchmark_extraction.py
@@ -31,23 +31,45 @@ def make_result_json(workspace_path, mets_path):
         'evaluation_results': extract_benchmarks(workspace_path, mets_path)
     }
 
+#    "eval_workflow": {
+#        "@id": "https://github.com/OCR-D/quiver/tree/data/workflows/eval1.nf",
+#        "label": "Evaluation Workflow 1"
+#      },
+#      "ocr_workspace": {
+#        "@id": "https://github.com/OCR-D/quiver/tree/data/workspaces/3000.ocrd.zip",
+#        "label": "OCR result workspace 3000"
+#      }
+
 def make_metadata(workspace_path, mets_path):
     return {
-            'data_creation_workflow': get_data_creation_workflow(workspace_path),
+            'ocr_workflow': get_ocr_workflow(workspace_path),
+            #'eval_workflow': get_eval_workflow(workspace_path),
+            'gt_workspace': get_gt_workspace(workspace_path),
+            #'ocr_workspace': get_ocr_workspace(workspace_path),
+            'eval_workspace': get_eval_workspace(workspace_path),
             'workflow_steps': get_workflow_steps(mets_path),
             'workflow_model': get_workflow_model(mets_path),
-            'eval_workflow_url': '',
-            'eval_data': '',
-            'eval_tool': get_eval_tool(mets_path),
-            'gt_data': get_gt_data_url(workspace_path),
-            'data_properties': ''
+            'document_metadata': ''
         }
 
-def get_data_creation_workflow(workspace_path):
+def get_ocr_workflow(workspace_path):
     for file_name in listdir(workspace_path):
         if '.txt.nf' in file_name:
             workflow = file_name.split('.')[0]
-    return 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/' + workflow + '.txt'
+    url = 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/' + workflow + '.txt'
+    label = f'OCR Workflow {workflow}'
+    return {'@id': url,
+        'label': label
+    }
+
+def get_eval_workspace(workspace_path):
+    workspace = workspace_path.split('/')[-2]
+    url = 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/' + workspace + '.zip'
+    label = f'Evaluation workspace for {workspace}'
+    return {
+        '@id': url,
+        'label': label
+    }
 
 def get_element_from_mets(mets_path, xpath):
     with open(mets_path, 'r', encoding='utf-8') as f:
@@ -74,9 +96,14 @@ def get_eval_tool(mets_path):
     xpath = f'.//{METS}agent[@OTHERROLE="recognition/text-recognition"]/{METS}name'
     return get_element_from_mets(mets_path, xpath)[0].text
 
-def get_gt_data_url(workspace_path):
+def get_gt_workspace(workspace_path):
     current_workspace = workspace_path.split('/')[-2]
-    return 'https://github.com/OCR-D/quiver-data/blob/main/' + current_workspace + '.ocrd.zip'
+    url = 'https://github.com/OCR-D/quiver-data/blob/main/' + current_workspace + '.ocrd.zip'
+    label = 'TODO'
+    return {
+        '@id': url,
+        'label': label
+    }
 
 def extract_benchmarks(workspace_path, mets_path):
     json_dirs = get_eval_jsons(workspace_path)

--- a/tests/test_benchmark_extraction.py
+++ b/tests/test_benchmark_extraction.py
@@ -7,8 +7,9 @@ from quiver.benchmark_extraction import get_cer_min_max
 from quiver.benchmark_extraction import get_eval_tool
 from quiver.benchmark_extraction import get_workflow_model
 from quiver.benchmark_extraction import get_workflow_steps
-from quiver.benchmark_extraction import get_gt_data_url
-from quiver.benchmark_extraction import get_data_creation_workflow
+from quiver.benchmark_extraction import get_gt_workspace
+from quiver.benchmark_extraction import get_ocr_workflow
+from quiver.benchmark_extraction import get_eval_workspace
 
 def test_get_eval_dirs():
     workspace_dir = 'tests/assets/benchmarking/16_ant_complex/'
@@ -92,12 +93,19 @@ def test_get_workflow_steps():
         'ocrd-dinglehopper',
         'ocrd-dinglehopper']
 
-def test_get_gt_data_url():
+def test_get_gt_workspace():
     workspace_path = 'tests/assets/benchmarking/16_ant_complex/'
-    result = get_gt_data_url(workspace_path)    
-    assert result == 'https://github.com/OCR-D/quiver-data/blob/main/16_ant_complex.ocrd.zip'
+    result = get_gt_workspace(workspace_path)    
+    assert result['@id'] == 'https://github.com/OCR-D/quiver-data/blob/main/16_ant_complex.ocrd.zip'
+    assert result['label'] == 'GT workspace 16th century antiqua'
 
-def test_get_data_creation_workflow():
+def test_get_ocr_workflow():
     workspace_path = 'tests/assets/benchmarking/16_ant_complex/'
-    result = get_data_creation_workflow(workspace_path)    
-    assert result == 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt'
+    result = get_ocr_workflow(workspace_path)
+    assert result['@id'] == 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/ocrd_workflows/minimal.txt'
+    assert result['label'] == 'OCR Workflow minimal'
+
+def test_get_eval_workspace():
+    workspace_path = 'tests/assets/benchmarking/16_ant_complex/'
+    result = get_eval_workspace(workspace_path)
+    assert result['@id'] == 'https://github.com/OCR-D/quiver-back-end/blob/main/workflows/results/16_ant_complex.zip'


### PR DESCRIPTION
The current implementation did not yet consider that we use JSON-LD for some properties in `metadata`. This PR introduces some of them, excluding the ones which can only be retrieved after separating OCR and evaluation (both of them are currently done in one workflow txt).